### PR TITLE
Fix: Add missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+git+https://github.com/cmacdonald/DeepCT.git
 python-terrier
 pandas
+torch
 transformers>=4.0


### PR DESCRIPTION
- Add DeepCT dependency as it's not installed by default.
- Added Pytorch dependency, may not be installed by default from transformers (at least not on my system).