### PR TITLE
Fix: Broken Jupyter Git link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ indexer.index(dataset.get_corpus_iter())
 ```
 
 ## Demos
- - vaswani.ipy - [[Github](blob/main/pyterrier_deepct_vaswani.ipynb)] [[Colab](https://colab.research.google.com/github/terrierteam/pyterrier_deepct/blob/main/pyterrier_deepct_vaswani.ipynb)] - demonstrates end-to-end indexing and retrieval on the Vaswani corpus (~11k documents)
+ - vaswani.ipy - [[Github](pyterrier_deepct_vaswani.ipynb)] [[Colab](https://colab.research.google.com/github/terrierteam/pyterrier_deepct/blob/main/pyterrier_deepct_vaswani.ipynb)] - demonstrates end-to-end indexing and retrieval on the Vaswani corpus (~11k documents)
 
 ## References
 


### PR DESCRIPTION
The link to the repository's notebook was broken.